### PR TITLE
Fix division by zero error

### DIFF
--- a/simpledorff/simpledorff.py
+++ b/simpledorff/simpledorff.py
@@ -74,7 +74,10 @@ def calculate_krippendorffs_alpha(ea_table_df, metric_fn=nominal_metric):
         frequency_dicts=frequency_dict, metric_fn=metric_fn
     )
     N = frequency_dict['total']
-    alpha = 1 - (observed_disagreement / expected_disagreement)*(N-1)
+    if expected_disagreement != 0:
+        alpha = 1 - (observed_disagreement / expected_disagreement)*(N-1)
+    else:
+        alpha = 1 * (N-1)
     return alpha
 
 


### PR DESCRIPTION
There is a division by zero error that occasionally occurs. I believe it happens when expected_disagreement is 0, so I tried to create an if statement to prevent this. Not entirely sure if it's mathematically sound  